### PR TITLE
Escape highlighting

### DIFF
--- a/language-examples/csharp.cs
+++ b/language-examples/csharp.cs
@@ -1,0 +1,1 @@
+String stringEscapes = "a\nb";

--- a/language-examples/html.html
+++ b/language-examples/html.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Page title</title>
+  </head>
+  <body>
+    <h1>First-level header</h1>
+
+    <h2>Second-level header</h2>
+    <ul>
+      <li>list</li>
+      <li>of</li>
+      <li>bullets</li>
+    </ul>
+
+    <h2>Another second-level header</h2>
+    <p>
+      This paragraph contains an escape&mdash;namely, the em dash.
+    </p>
+  </body>
+</html>

--- a/language-examples/java.java
+++ b/language-examples/java.java
@@ -1,0 +1,1 @@
+String stringEscapes = "a\nb";

--- a/language-examples/javascript.js
+++ b/language-examples/javascript.js
@@ -6,6 +6,7 @@ function func(param) {
     }
     var number = 0;
     var templateLiterals = `a ${text} b ${1 + 2} c`;
+    var escapes = 'line 1\nline 2';
     return {
         "text": text,
         "boolean": false,

--- a/language-examples/markdown.md
+++ b/language-examples/markdown.md
@@ -1,0 +1,1 @@
+String&nbsp;escapes

--- a/language-examples/typescript.ts
+++ b/language-examples/typescript.ts
@@ -6,6 +6,7 @@ function func(param: string): object {
     }
     var number = 0;
     var templateLiterals = `a ${text} b ${1 + 2} c`;
+    var escapes = 'line 1\nline 2';
     return {
         "text": text,
         "boolean": false,

--- a/src/color.ts
+++ b/src/color.ts
@@ -58,6 +58,7 @@ export function generateFallbackColorSet(s: IBaseColorSet, type: 'light' | 'dark
       number: s.color4,
       storage: s.color1,
       string: s.color2,
+      stringEscape: (type === 'light' ? darken : lighten)(s.color2, 0.5),
       comment: (type === 'light' ? darken : lighten)(s.background, 2.0),
       class: s.color3,
       classMember: s.color3,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface IColorSet {
     number?: string;
     storage?: string;
     string?: string;
+    stringEscape?: string;
     comment?: string;
     class?: string;
     classMember?: string;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -71,6 +71,7 @@ export const tokenRules: IRuleGenerator[] = [
   // string: It's important that string is put first so that other scopes can override strings
   // within template expressions
   { color: s => s.syntax.string,       generate: getSimpleColorGenerator('String', 'string') },
+  { color: s => s.syntax.stringEscape, generate: getSimpleColorGenerator('String Escape', 'constant.character.escape, text.html constant.character.entity.named, punctuation.definition.entity.html') },
   { color: s => s.syntax.boolean,      generate: getSimpleColorGenerator('Boolean', 'constant.language.boolean') },
   { color: s => s.syntax.number,       generate: getSimpleColorGenerator('Number', 'constant.numeric') },
   { color: s => s.syntax.identifier,   generate: getSimpleColorGenerator('Identifier', 'variable, support.variable, support.class, support.constant, meta.definition.variable entity.name.function') },


### PR DESCRIPTION
Resolves #50. Adds `stringEscape` to `syntax`, which uses a lightened `color2` as fallback.

Currently, `stringEscape` covers both the escape characters originally mentioned in #50 and the HTML entities form #46. Would it make more sense to have a separate property for HTML?

If both this and #55 get merged, whichever one comes second should also update README.md to mention `stringEscape`.